### PR TITLE
import :: from List explicitly

### DIFF
--- a/src/Svg.elm
+++ b/src/Svg.elm
@@ -40,6 +40,7 @@ module Svg where
 @docs clipPath, colorProfile, cursor, filter, script, style, view
 -}
 
+import List ((::))
 import Html
 import VirtualDom
 import Json.Encode as Json


### PR DESCRIPTION
Good day!

I was getting the following error (which should not even be possible, given the default imports, so I am perplexed by that):

```

Error in package evancz/elm-svg 1.0.0 in module Svg:

Error on line 60, column 25 to 51:
Could not find variable '::'.


This error is probably due to bad version bounds. You should definitely
inform the maintainer of evancz/elm-svg to get this fixed.

In the meantime, you can attempt to get rid of the problematic dependency by
modifying elm-stuff/exact-dependencies.json, though that is not a long term
solution.
```

This little change fixes it for me.
