### PR TITLE
VirtualDom interfering with Svg node discovery

### DIFF
--- a/svg-xlink-fail/Nestedanimationok.elm
+++ b/svg-xlink-fail/Nestedanimationok.elm
@@ -1,0 +1,24 @@
+-- module Oops where
+import Html
+import Html.Attributes as H
+import Svg exposing ( .. )
+import Svg.Attributes as S
+
+main = svg [ H.attribute "width" "1000px"
+           , H.attribute "height" "1000px" ]
+       [ rect [ S.id     "test-rectangle"
+              , S.x      "25"
+              , S.y      "25"
+              , S.width  "50"
+              , S.height "50" ]
+         [
+          animateTransform [ S.xlinkHref     "#test-rectangle"
+                           , S.attributeName "transform"
+                           , S.type'         "rotate"
+                           , S.values        "0 0 0; 360 0 0"
+                           , S.additive      "sum"
+                           , S.dur           "6s"
+                           , S.repeatCount   "indefinite" ]
+          []
+         ]
+       ]

--- a/svg-xlink-fail/Xlinkattributefail.elm
+++ b/svg-xlink-fail/Xlinkattributefail.elm
@@ -1,0 +1,25 @@
+-- module Oops where
+import Html
+import Html.Attributes as H
+import Svg exposing ( .. )
+import Svg.Attributes as S
+
+main = svg [ H.attribute "width" "1000px"
+           , H.attribute "height" "1000px" ]
+       [ defs []
+                  [ animateTransform [ S.xlinkHref     "#test-rectangle"
+                                     , S.attributeName "transform"
+                                     , S.type'         "rotate"
+                                     , S.values        "0 0 0; 360 0 0"
+                                     , S.additive      "sum"
+                                     , S.dur           "6s"
+                                     , S.repeatCount   "indefinite" ]
+                    []
+                  ]
+       , rect [ S.id     "test-rectangle"
+              , S.x      "25"
+              , S.y      "25"
+              , S.width  "50"
+              , S.height "50" ]
+         []
+       ]

--- a/svg-xlink-fail/Xlinkattributefail.html
+++ b/svg-xlink-fail/Xlinkattributefail.html
@@ -1,0 +1,11 @@
+<!-- Elm generated html snippet (from Xlinkattributefail.elm )-->
+<!-- The transform attribute has been added to the defs tag, because svg could not find the referenced xlink:href element -->
+<div>
+    <svg width="1000px" height="1000px">
+        <defs transform="rotate(70.0447)">
+            <animateTransform xlink:href="#test-rectangle" attributeName="transform" type="rotate" values="0 0 0; 360 0 0" additive="sum" dur="6s" repeatCount="indefinite">
+            </animateTransform>
+        </defs>
+        <rect id="test-rectangle" x="25" y="25" width="50" height="50"></rect>
+    </svg>
+</div>

--- a/svg-xlink-fail/working-svg.html
+++ b/svg-xlink-fail/working-svg.html
@@ -1,0 +1,10 @@
+<html>
+    <body>
+        <svg>
+            <defs>
+                <animatetransform xlink:href="test-rectangle" attributename="transform" type="rotate" values="0 0 0; 360 0 0" additive="sum" dur="6s" repeatCount="indefinite" />
+            </defs>
+            <rect id="test-rectangle" x="25" y="25" width="50" height="50">
+        </svg>
+    </body>
+</html>


### PR DESCRIPTION
The VirtualDom appears to inject nodes in a manner such that Svg cannot resolve xlink:href references (see example files in pull request). Unfortunately I don't know enough about the VirtualDom to suggest a solution.

The xlink:href attribute is a great abstraction that sits nicely with elm (and provides better performance as fewer Dom mutations), so although there's a workaround attached (via nesting tags), it's clumsy and makes elm code look messy.
